### PR TITLE
Responsivité de la media query pour mobile 

### DIFF
--- a/CSS/styles.css
+++ b/CSS/styles.css
@@ -583,7 +583,12 @@ h2 {
 
     .populaires-cards {
         display: flex;
-        flex-direction: column;    
+        flex-direction: column; 
+        width: 100%;   
+    }
+
+    .populaires-cards a {
+        width: auto;
     }
 
     .populaires-cards .card {


### PR DESCRIPTION
pour que la Carte populaire prenne 100% de l'écran